### PR TITLE
[#62] allow custom set date string format

### DIFF
--- a/prose/core/image.py
+++ b/prose/core/image.py
@@ -53,6 +53,9 @@ class Image:
     computed: dict = None
     """A dictionary containing any user and block-defined attributes"""
 
+    telescope: Telescope = None
+    """Image telescope information"""
+
     _wcs = None
 
     def __post_init__(self):
@@ -249,7 +252,7 @@ class Image:
         -------
         datetime.datetime
         """
-        return dparser.parse(self.metadata["date"])
+        return self.telescope.date(self.metadata["date"])
 
     @property
     def night_date(self):
@@ -574,7 +577,7 @@ def FITSImage(
 
     image = Image(values, metadata, {})
     if image.metadata["jd"] is None:
-        image.metadata["jd"] = Time(image.date).jd
+        image.metadata["jd"] = Time(telescope.date(image.metadata["date"])).jd
     image.fits_header = header
     image.wcs = WCS(header)
     image.telescope = telescope

--- a/prose/core/image.py
+++ b/prose/core/image.py
@@ -53,9 +53,6 @@ class Image:
     computed: dict = None
     """A dictionary containing any user and block-defined attributes"""
 
-    telescope: Telescope = None
-    """Image telescope information"""
-
     _wcs = None
 
     def __post_init__(self):
@@ -252,7 +249,7 @@ class Image:
         -------
         datetime.datetime
         """
-        return self.telescope.date(self.metadata["date"])
+        return dparser.parse(self.metadata["date"])
 
     @property
     def night_date(self):
@@ -554,7 +551,7 @@ def FITSImage(
         "ra": header.get(telescope.keyword_ra, None),
         "dec": header.get(telescope.keyword_dec, None),
         "filter": header.get(telescope.keyword_filter, None),
-        "date": header.get(telescope.keyword_observation_date, None),
+        "date": telescope.date(header).isoformat(),
         "jd": header.get(telescope.keyword_jd, None),
         "object": header.get(telescope.keyword_object, None),
         "pixel_scale": telescope.pixel_scale,
@@ -577,7 +574,7 @@ def FITSImage(
 
     image = Image(values, metadata, {})
     if image.metadata["jd"] is None:
-        image.metadata["jd"] = Time(telescope.date(image.metadata["date"])).jd
+        image.metadata["jd"] = Time(image.date).jd
     image.fits_header = header
     image.wcs = WCS(header)
     image.telescope = telescope

--- a/prose/io/io.py
+++ b/prose/io/io.py
@@ -132,7 +132,7 @@ def fits_to_df(
         df_list.append(
             dict(
                 path=i,
-                date=_telescope.header_date(header).isoformat(),
+                date=_telescope.date(header).isoformat(),
                 telescope=_telescope.name,
                 type=_telescope.image_type(header),
                 target=header.get(_telescope.keyword_object, ""),

--- a/prose/io/io.py
+++ b/prose/io/io.py
@@ -132,7 +132,7 @@ def fits_to_df(
         df_list.append(
             dict(
                 path=i,
-                date=_telescope.date(header).isoformat(),
+                date=_telescope.header_date(header).isoformat(),
                 telescope=_telescope.name,
                 type=_telescope.image_type(header),
                 target=header.get(_telescope.keyword_object, ""),

--- a/prose/telescope.py
+++ b/prose/telescope.py
@@ -147,6 +147,9 @@ class Telescope:
     camera_name: str = None
     """name of the telescope camera, default is :code:`None`"""
 
+    date_string_format: str = None
+    """date string format, default is :code:`None`"""
+
     _default: bool = True
     save: bool = False
 
@@ -226,12 +229,19 @@ class Telescope:
 
         return telescope
 
-    def date(self, header):
-        header_date = header.get(self.keyword_observation_date, None)
-        if header_date is not None:
-            return dparser.parse(header_date)
+    def date(self, header_date_str):
+        if header_date_str is not None:
+            if self.date_string_format is not None:
+                return datetime.strptime(header_date_str, self.date_string_format)
+            else:
+                return dparser.parse(header_date_str)
         else:
             return datetime(1800, 1, 2)
+    
+    def header_date(self, header):
+        header_date_str = header.get(self.keyword_observation_date, None)
+        return self.date(header_date_str)
+
 
     def image_type(self, header):
         return header.get(self.keyword_image_type, "").lower()

--- a/prose/telescope.py
+++ b/prose/telescope.py
@@ -229,7 +229,8 @@ class Telescope:
 
         return telescope
 
-    def date(self, header_date_str):
+    def date(self, header):
+        header_date_str = header.get(self.keyword_observation_date, None)
         if header_date_str is not None:
             if self.date_string_format is not None:
                 return datetime.strptime(header_date_str, self.date_string_format)
@@ -237,11 +238,6 @@ class Telescope:
                 return dparser.parse(header_date_str)
         else:
             return datetime(1800, 1, 2)
-    
-    def header_date(self, header):
-        header_date_str = header.get(self.keyword_observation_date, None)
-        return self.date(header_date_str)
-
 
     def image_type(self, header):
         return header.get(self.keyword_image_type, "").lower()

--- a/tests/test_telescope.py
+++ b/tests/test_telescope.py
@@ -1,7 +1,13 @@
 from prose import Telescope
 from prose import CONFIG
-
+from datetime import datetime
 
 def test_creation(name="test_telescope"):
     Telescope(name=name, save=True)
     assert name in CONFIG.build_telescopes_dict().keys()
+
+def test_header_date(name="test_telescope"):
+    telescope = Telescope(name=name, save=True)
+    telescope.date_string_format = '%Y:%m:%d:%H:%M:%S.%f'
+    date = telescope.date('2023:02:16:19:38:54.250')
+    assert date == datetime(2023, 2, 16, 19, 38, 54, 250000)

--- a/tests/test_telescope.py
+++ b/tests/test_telescope.py
@@ -1,13 +1,25 @@
-from prose import Telescope
+from prose import Telescope, Image, FITSImage
 from prose import CONFIG
 from datetime import datetime
+from astropy.io.fits import Header
 
 def test_creation(name="test_telescope"):
     Telescope(name=name, save=True)
     assert name in CONFIG.build_telescopes_dict().keys()
 
-def test_header_date(name="test_telescope"):
-    telescope = Telescope(name=name, save=True)
+def test_custom_header_date(tmp_path):
+    im = Image()
+    im.header = Header()
+
+    keyword = 'OBSTIME'
+    value = '2023:02:16:19:38:54.250'
+
+    im.header[keyword] = value
+    im.writeto(tmp_path / "test.fits")
+
+    telescope = Telescope(keyword_observation_date=keyword)
     telescope.date_string_format = '%Y:%m:%d:%H:%M:%S.%f'
-    date = telescope.date('2023:02:16:19:38:54.250')
-    assert date == datetime(2023, 2, 16, 19, 38, 54, 250000)
+
+    im = FITSImage(tmp_path / "test.fits", load_data=False, telescope=telescope)
+
+    assert im.date == datetime(2023, 2, 16, 19, 38, 54, 250000)


### PR DESCRIPTION
allow custom set date string format according to [this](https://github.com/lgrcia/prose/issues/62#issuecomment-1474674694)
- add `date_string_format` in Telescope
- Uniform use of `telescope` method `date` to parse time
- add a test