### PR TITLE
fix: iso format mismatch in fits_to_df

### DIFF
--- a/prose/io/io.py
+++ b/prose/io/io.py
@@ -133,7 +133,7 @@ def fits_to_df(
         df_list.append(
             dict(
                 path=i,
-                date=_telescope.date(header).isoformat(),
+                date=_telescope.date(header),
                 telescope=_telescope.name,
                 type=_telescope.image_type(header),
                 target=header.get(_telescope.keyword_object, ""),


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / dependencies update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/lgrcia/prose/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/lgrcia/prose/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using [black](https://black.readthedocs.io/en/stable/).
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in [numpy style](https://numpydoc.readthedocs.io/en/latest/format.html#documenting-classes) for all the methods and classes that I used.
