### PR TITLE
fix: trace aperture height always > 0

### DIFF
--- a/prose/core/source.py
+++ b/prose/core/source.py
@@ -274,6 +274,8 @@ class Source:
             a, b = 2 * r * self.a, 2 * r * self.b
         else:
             a, b = 2 * r, 2 * r * self.eccentricity
+        a = np.max([0.01, a])
+        b = np.max([0.01, b])
         return RectangularAperture(
             self.coords, float(np.abs(a)), float(np.abs(b)), self.orientation
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prose"
-version = "3.0.1"
+version = "3.0.2"
 description = "Modular image processing pipelines for Astronomy"
 authors = ["Lionel Garcia"]
 license = "MIT"


### PR DESCRIPTION
## Description

fix: trace aperture height always > 0. The fact that it could be 0 messed up the source tutorial (that is based on a random image example so sometimes the trace source has a height of 0). I could have seed the example image but this is a more general and durable fix.