### PR TITLE
feat: XYShift block for translation transform

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,6 +38,7 @@ If at the idea stage, feel free to [open an issue](https://github.com/lgrcia/pro
 
 ### Coding style
 For core developments, here are some style guidelines we try to stick to:
+- commit messages using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
 - [black](https://black.readthedocs.io/en/stable/) formatting with a 88 characters line limit
 - explicit variable name is preferred over comments
 - extensive comments

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,10 +6,6 @@ prose intends to be a package for image processing and stops whenever your scien
     <img src="_static/core_h.png" width="700">
 </p>
 
-With that in mind, there are few ways to contribute to prose:
-- *field-specific developments*: you want to use prose in a particular field of Astronomy (e.g. develop a new `Block` or new products)
-- *core developments*: you want to make changes to prose documentation or its core objects (e.g. `Image` or `Sequence`)
-
 ## Get started
 
 1. [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the github repository
@@ -17,27 +13,7 @@ With that in mind, there are few ways to contribute to prose:
 3. Modify the source code, commit and push
 4. Make a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
 
-## Field-specific developments
-
-If you want to adapt prose to your own field of Astronomy (e.g. comets, exoplanets, galaxies, space debris... etc) you may want to develop a package using prose rather than making core changes. This is particularly true if you need to develop methods targeting specific products, located after the image processing (see top schematic). Even if being independent in your developments, there are few ways this could contribute to prose, and the community can help.
-
-### Support
-If you have any question about your application or need support to use prose, [open an issue](https://github.com/lgrcia/prose/issues/new?labels=idea&title=Your+idea) or [open a discussion](https://github.com/lgrcia/prose/discussions/new?category=ideas&title=My+idea). Describe your idea and potential use cases, so that users familiar with your application can help, but also agnostic contributors. Keep in mind that your idea might be worth making core changes, so users outside of your field can benefit from it.
-
-### Acknowledgement
-If you develop tools for a specific field, chances are your developments are worth a separate Python package, so that your community can benefit from your work and cite it.
-
-If working in Academia, we strongly encourage and fully support publishing your work in the [Journal of Open Source Software](https://joss.theoj.org/), so that your package can be referenced and cited by others.
-
-## Core developments
-
-Core developments concern changes you want to make on the core objects of prose (e.g. `Image`, `Block` and `Sequence`). These will affect all pipelines written in prose and benefit all sort of applications. Core developments go from fixing a typo in the documentation to integrating new features.
-
-### Submitting code
-If at the idea stage, feel free to [open an issue](https://github.com/lgrcia/prose/issues/new?labels=idea&title=Your+idea) to discuss about it. If already developed, open a pull request. Whatever stage you are in, try to describe your idea to people not in your field and add a use case and code examples.
-
-### Coding style
-For core developments, here are some style guidelines we try to stick to:
+## Coding style
 - commit messages using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
 - [black](https://black.readthedocs.io/en/stable/) formatting with a 88 characters line limit
 - explicit variable name is preferred over comments
@@ -45,8 +21,32 @@ For core developments, here are some style guidelines we try to stick to:
 - [numpy style](https://numpydoc.readthedocs.io/en/latest/format.html#documenting-classes) docstrings
 - tests with [pytest](https://docs.pytest.org/en/7.2.x/)
 
-No matter your level of familiarity with any of these guidelines, we can all help to make your code compliant, so feel free to propose non-formatted code.
+## Types of developments
 
-### Acknowledgement
+There are few ways to contribute to prose:
+- *field-specific developments*: you want to use prose in a particular field of Astronomy (e.g. develop a new `Block` or new products)
+- *core developments*: you want to make changes to prose documentation or its core objects (e.g. `Image` or `Sequence`)
+
+
+### Field-specific developments
+
+If you want to adapt prose to your own field of Astronomy (e.g. comets, exoplanets, galaxies, space debris... etc) you may want to develop a package using prose rather than making core changes. This is particularly true if you need to develop methods targeting specific products, located after the image processing (see top schematic). Even if being independent in your developments, there are few ways this could contribute to prose, and the community can help.
+
+#### Support
+If you have any question about your application or need support to use prose, [open an issue](https://github.com/lgrcia/prose/issues/new?labels=idea&title=Your+idea) or [open a discussion](https://github.com/lgrcia/prose/discussions/new?category=ideas&title=My+idea). Describe your idea and potential use cases, so that users familiar with your application can help, but also agnostic contributors. Keep in mind that your idea might be worth making core changes, so users outside of your field can benefit from it.
+
+#### Acknowledgement
+If you develop tools for a specific field, chances are your developments are worth a separate Python package, so that your community can benefit from your work and cite it.
+
+If working in Academia, we strongly encourage and fully support publishing your work in the [Journal of Open Source Software](https://joss.theoj.org/), so that your package can be referenced and cited by others.
+
+### Core developments
+
+Core developments concern changes you want to make on the core objects of prose (e.g. `Image`, `Block` and `Sequence`). These will affect all pipelines written in prose and benefit all sort of applications. Core developments go from fixing a typo in the documentation to integrating new features.
+
+#### Submitting code
+If at the idea stage, feel free to [open an issue](https://github.com/lgrcia/prose/issues/new?labels=idea&title=Your+idea) to discuss about it. If already developed, open a pull request. Whatever stage you are in, try to describe your idea to people not in your field and add a use case and code examples.
+
+#### Acknowledgement
 
 We intend to publish an update paper whenever a major version is released and used by the community (in order to showcase nice applications). Making core contributions (fixing typos in the documentation included) is extremely valuable and will make you part of the next paper release (a get you free stickers!).

--- a/prose/blocks/alignment.py
+++ b/prose/blocks/alignment.py
@@ -4,7 +4,8 @@ from skimage.transform import warp
 
 from prose.core import Block, Image
 
-from .geometry import ComputeTransform, SetAffineTransform
+from .geometry import (ComputeTransform, ComputeTransformTwirl,
+                       ComputeTransformXYShift, SetAffineTransform)
 
 __all__ = ["Align", "AlignReferenceSources", "AlignReferenceWCS"]
 
@@ -42,7 +43,7 @@ class Align(Block):
 
 
 class AlignReferenceSources(Block):
-    def __init__(self, reference: Image, name=None, verbose=False):
+    def __init__(self, reference: Image, name=None, verbose=False, XYShift=False):
         """Set Image sources to reference Image sources, properly aligned
 
         |read| Image.sources
@@ -60,7 +61,8 @@ class AlignReferenceSources(Block):
         """
         super().__init__(name, verbose)
         self.reference_sources = reference.sources
-        self.compute_transform = ComputeTransform(reference)
+        self.compute_transform = ComputeTransformXYShift(reference) if XYShift else ComputeTransformTwirl(reference)
+        #self.compute_transform = ComputeTransform(reference)
         self._parallel_friendly = True
 
     def run(self, image: Image):
@@ -110,3 +112,6 @@ class AlignReferenceWCS(Block):
         image.wcs = fit_wcs_from_points(
             image.sources.coords[0 : self.n].T, ref_skycoords
         )
+        
+        
+####EDIT####

--- a/prose/blocks/alignment.py
+++ b/prose/blocks/alignment.py
@@ -62,7 +62,6 @@ class AlignReferenceSources(Block):
         super().__init__(name, verbose)
         self.reference_sources = reference.sources
         self.compute_transform = ComputeTransformXYShift(reference) if XYShift else ComputeTransformTwirl(reference)
-        #self.compute_transform = ComputeTransform(reference)
         self._parallel_friendly = True
 
     def run(self, image: Image):
@@ -112,6 +111,3 @@ class AlignReferenceWCS(Block):
         image.wcs = fit_wcs_from_points(
             image.sources.coords[0 : self.n].T, ref_skycoords
         )
-        
-        
-####EDIT####

--- a/prose/blocks/alignment.py
+++ b/prose/blocks/alignment.py
@@ -4,8 +4,12 @@ from skimage.transform import warp
 
 from prose.core import Block, Image
 
-from .geometry import (ComputeTransform, ComputeTransformTwirl,
-                       ComputeTransformXYShift, SetAffineTransform)
+from .geometry import (
+    ComputeTransform,
+    ComputeTransformTwirl,
+    ComputeTransformXYShift,
+    SetAffineTransform,
+)
 
 __all__ = ["Align", "AlignReferenceSources", "AlignReferenceWCS"]
 
@@ -61,7 +65,11 @@ class AlignReferenceSources(Block):
         """
         super().__init__(name, verbose)
         self.reference_sources = reference.sources
-        self.compute_transform = ComputeTransformXYShift(reference) if XYShift else ComputeTransformTwirl(reference)
+        self.compute_transform = (
+            ComputeTransformXYShift(reference)
+            if XYShift
+            else ComputeTransformTwirl(reference)
+        )
         self._parallel_friendly = True
 
     def run(self, image: Image):

--- a/prose/blocks/geometry.py
+++ b/prose/blocks/geometry.py
@@ -208,8 +208,8 @@ class Drizzle(Block):
         self.image.data = self.drizzle.outsci
 
 
-
 ### EDIT ###
+
 
 class ComputeTransformTwirl(Block):
     """
@@ -277,8 +277,8 @@ class ComputeTransformTwirl(Block):
             i, j = matches
 
         return twirl_utils._find_transform(s[j], self.ref[i])
-    
-    
+
+
 class ComputeTransformXYShift(Block):
     """
     Compute translational transformation (dx, dy) of a target image from a reference image
@@ -291,31 +291,32 @@ class ComputeTransformXYShift(Block):
     ----------
     ref : Image
         image containing detected sources
+    n : int, optional
+        number of stars to consider to compute transformation, by default 10
     """
 
-    def __init__(self, reference_image: Image, discard=True, **kwargs):
-        
+    def __init__(self, reference_image: Image, n=10, discard=True, **kwargs):
         super().__init__(**kwargs)
         ref_coords = reference_image.sources.coords
+        self.n = n
         self.ref_coords = ref_coords[0:n].copy()
         self.discard = discard
         self._parallel_friendly = True
 
     def run(self, image):
-        
         if len(image.sources.coords) >= 5:
             if len(image.sources.coords) <= 2:
                 shift = self.ref_coords[0] - image.sources.coords[0]
             else:
-                shift = self.xyshift(image.sources.coords, self.ref_coords) # TODO implement tolerance parameter for more modularity?
+                shift = self.xyshift(
+                    image.sources.coords, self.ref_coords
+                )
             if shift is not None:
                 image.transform = AffineTransform(translation=shift)
             else:
                 image.discard = True
         else:
             image.discard = True
-            
-
 
     def xyshift(self, im_stars_pos, ref_stars_pos, tolerance=1.5):
         """
@@ -337,8 +338,10 @@ class ComputeTransformXYShift(Block):
         ndarray
             (dx, dy) shift
         """
-        assert len(im_stars_pos) > 2, f"{len(im_stars_pos)} star coordinates provided (should be > 2)"
-        
+        assert (
+            len(im_stars_pos) > 2
+        ), f"{len(im_stars_pos)} star coordinates provided (should be > 2)"
+
         clean_ref = ref_stars_pos
         clean_im = im_stars_pos
 

--- a/prose/blocks/geometry.py
+++ b/prose/blocks/geometry.py
@@ -281,7 +281,7 @@ class ComputeTransformTwirl(Block):
     
 class ComputeTransformXYShift(Block):
     """
-    Compute transformation fromm a reference image
+    Compute translational transformation (dx, dy) of a target image from a reference image
 
     |read| ``Image.sources`` on both reference and input image
 
@@ -291,18 +291,13 @@ class ComputeTransformXYShift(Block):
     ----------
     ref : Image
         image containing detected sources
-    n : int, optional
-        number of stars to consider to compute transformation, by default 10
     """
 
-    def __init__(self, reference_image: Image, n=10, discard=True, **kwargs):
+    def __init__(self, reference_image: Image, discard=True, **kwargs):
         
         super().__init__(**kwargs)
         ref_coords = reference_image.sources.coords
         self.ref_coords = ref_coords[0:n].copy()
-        self.n = n
-        self.quads_ref, self.stars_ref = twirl_utils.quads_stars(ref_coords, n=n)
-        self.KDTree = KDTree(self.quads_ref)
         self.discard = discard
         self._parallel_friendly = True
 
@@ -312,8 +307,7 @@ class ComputeTransformXYShift(Block):
             if len(image.sources.coords) <= 2:
                 shift = self.ref_coords[0] - image.sources.coords[0]
             else:
-                shift = self.xyshift(image.sources.coords, self.ref_coords) # TODO implement tolerance parameter for more modularity
-            #result = self.solve(image.sources.coords) #dx, dy from XYshift
+                shift = self.xyshift(image.sources.coords, self.ref_coords) # TODO implement tolerance parameter for more modularity?
             if shift is not None:
                 image.transform = AffineTransform(translation=shift)
             else:

--- a/prose/blocks/geometry.py
+++ b/prose/blocks/geometry.py
@@ -206,3 +206,207 @@ class Drizzle(Block):
 
     def terminate(self):
         self.image.data = self.drizzle.outsci
+
+
+
+### EDIT ###
+
+class ComputeTransformTwirl(Block):
+    """
+    Compute transformation fromm a reference image
+
+    |read| ``Image.sources`` on both reference and input image
+
+    |write| ``Image.transform``
+
+    Parameters
+    ----------
+    ref : Image
+        image containing detected sources
+    n : int, optional
+        number of stars to consider to compute transformation, by default 10
+    """
+
+    def __init__(self, reference_image: Image, n=10, discard=True, **kwargs):
+        super().__init__(**kwargs)
+        ref_coords = reference_image.sources.coords
+        self.ref = ref_coords[0:n].copy()
+        self.n = n
+        self.quads_ref, self.stars_ref = twirl_utils.quads_stars(ref_coords, n=n)
+        self.KDTree = KDTree(self.quads_ref)
+        self.discard = discard
+        self._parallel_friendly = True
+
+    def run(self, image):
+        if len(image.sources.coords) >= 5:
+            result = self.solve(image.sources.coords)
+            if result is not None:
+                image.transform = AffineTransform(result)
+            else:
+                image.discard = True
+        else:
+            image.discard = True
+
+    def solve(self, coords, tolerance=2):
+        s = coords.copy()
+        quads, stars = twirl_utils.quads_stars(s, n=self.n)
+        _, indices = self.KDTree.query(quads)
+
+        # We pick the two asterismrefs leading to the highest stars matching
+        closeness = []
+        for i, m in enumerate(indices):
+            M = twirl_utils._find_transform(self.stars_ref[m], stars[i])
+            new_ref = twirl_utils.affine_transform(M)(self.ref)
+            closeness.append(
+                twirl_utils._count_cross_match(s, new_ref, tolerance=tolerance)
+            )
+
+        i = np.argmax(closeness)
+        m = indices[i]
+        S1 = self.stars_ref[m]
+        S2 = stars[i]
+        M = twirl_utils._find_transform(S1, S2)
+        new_ref = twirl_utils.affine_transform(M)(self.ref)
+
+        matches = twirl_utils.cross_match(
+            new_ref, s, tolerance=tolerance, return_ixds=True
+        ).T
+        if len(matches) == 0:
+            return None
+        else:
+            i, j = matches
+
+        return twirl_utils._find_transform(s[j], self.ref[i])
+    
+    
+class ComputeTransformXYShift(Block):
+    """
+    Compute transformation fromm a reference image
+
+    |read| ``Image.sources`` on both reference and input image
+
+    |write| ``Image.transform``
+
+    Parameters
+    ----------
+    ref : Image
+        image containing detected sources
+    n : int, optional
+        number of stars to consider to compute transformation, by default 10
+    """
+
+    def __init__(self, reference_image: Image, n=10, discard=True, **kwargs):
+        
+        super().__init__(**kwargs)
+        ref_coords = reference_image.sources.coords
+        self.ref_coords = ref_coords[0:n].copy()
+        self.n = n
+        self.quads_ref, self.stars_ref = twirl_utils.quads_stars(ref_coords, n=n)
+        self.KDTree = KDTree(self.quads_ref)
+        self.discard = discard
+        self._parallel_friendly = True
+
+    def run(self, image):
+        
+        if len(image.sources.coords) >= 5:
+            if len(image.sources.coords) <= 2:
+                shift = self.ref_coords[0] - image.sources.coords[0]
+            else:
+                shift = self.xyshift(image.sources.coords, self.ref_coords) # TODO implement tolerance parameter for more modularity
+            #result = self.solve(image.sources.coords) #dx, dy from XYshift
+            if shift is not None:
+                image.transform = AffineTransform(translation=shift)
+            else:
+                image.discard = True
+        else:
+            image.discard = True
+            
+
+
+    def xyshift(self, im_stars_pos, ref_stars_pos, tolerance=1.5):
+        """
+        Compute shift between two set of coordinates (e.g. stars)
+
+        Parameters
+        ----------
+        im_stars_pos : list or ndarray
+            (x,y) coordinates of n points (shape should be (2, n))
+        ref_stars_pos : list or ndarray
+            [(x,y) coordinates of n points (shape should be (2, n)). Reference set
+        tolerance : float, optional
+            by default 1.5
+        clean : bool, optional
+            Merge coordinates if too close, by default False
+
+        Returns
+        -------
+        ndarray
+            (dx, dy) shift
+        """
+        assert len(im_stars_pos) > 2, f"{len(im_stars_pos)} star coordinates provided (should be > 2)"
+        
+        clean_ref = ref_stars_pos
+        clean_im = im_stars_pos
+
+        delta_x = np.array([clean_ref[:, 0] - v for v in clean_im[:, 0]]).flatten()
+        delta_y = np.array([clean_ref[:, 1] - v for v in clean_im[:, 1]]).flatten()
+
+        delta_x_compare = []
+        for i, dxi in enumerate(delta_x):
+            dcxi = dxi - delta_x
+            dcxi[i] = np.inf
+            delta_x_compare.append(dcxi)
+
+        delta_y_compare = []
+        for i, dyi in enumerate(delta_y):
+            dcyi = dyi - delta_y
+            dcyi[i] = np.inf
+            delta_y_compare.append(dcyi)
+
+        tests = [
+            np.logical_and(np.abs(dxc) < tolerance, np.abs(dyc) < tolerance)
+            for dxc, dyc in zip(delta_x_compare, delta_y_compare)
+        ]
+        num = np.array([np.count_nonzero(test) for test in tests])
+
+        max_count_num_i = int(np.argmax(num))
+        max_nums_ids = np.argwhere(num == num[max_count_num_i]).flatten()
+        dxs = np.array([delta_x[np.where(tests[i])] for i in max_nums_ids])
+        dys = np.array([delta_y[np.where(tests[i])] for i in max_nums_ids])
+
+        return np.nan_to_num(np.array([np.mean(dxs), np.mean(dys)]))
+    
+    def solve(self, coords, tolerance=2):
+        s = coords.copy()
+        
+        ##INPUT xyshift function here##
+        
+        
+        """ quads, stars = twirl_utils.quads_stars(s, n=self.n)
+        _, indices = self.KDTree.query(quads)
+
+        # We pick the two asterismrefs leading to the highest stars matching
+        closeness = []
+        for i, m in enumerate(indices):
+            M = twirl_utils._find_transform(self.stars_ref[m], stars[i])
+            new_ref = twirl_utils.affine_transform(M)(self.ref)
+            closeness.append(
+                twirl_utils._count_cross_match(s, new_ref, tolerance=tolerance)
+            )
+
+        i = np.argmax(closeness)
+        m = indices[i]
+        S1 = self.stars_ref[m]
+        S2 = stars[i]
+        M = twirl_utils._find_transform(S1, S2)
+        new_ref = twirl_utils.affine_transform(M)(self.ref)
+
+        matches = twirl_utils.cross_match(
+            new_ref, s, tolerance=tolerance, return_ixds=True
+        ).T
+        if len(matches) == 0:
+            return None
+        else:
+            i, j = matches
+
+        return twirl_utils._find_transform(s[j], self.ref[i]) """

--- a/prose/blocks/geometry.py
+++ b/prose/blocks/geometry.py
@@ -375,38 +375,3 @@ class ComputeTransformXYShift(Block):
         dys = np.array([delta_y[np.where(tests[i])] for i in max_nums_ids])
 
         return np.nan_to_num(np.array([np.mean(dxs), np.mean(dys)]))
-    
-    def solve(self, coords, tolerance=2):
-        s = coords.copy()
-        
-        ##INPUT xyshift function here##
-        
-        
-        """ quads, stars = twirl_utils.quads_stars(s, n=self.n)
-        _, indices = self.KDTree.query(quads)
-
-        # We pick the two asterismrefs leading to the highest stars matching
-        closeness = []
-        for i, m in enumerate(indices):
-            M = twirl_utils._find_transform(self.stars_ref[m], stars[i])
-            new_ref = twirl_utils.affine_transform(M)(self.ref)
-            closeness.append(
-                twirl_utils._count_cross_match(s, new_ref, tolerance=tolerance)
-            )
-
-        i = np.argmax(closeness)
-        m = indices[i]
-        S1 = self.stars_ref[m]
-        S2 = stars[i]
-        M = twirl_utils._find_transform(S1, S2)
-        new_ref = twirl_utils.affine_transform(M)(self.ref)
-
-        matches = twirl_utils.cross_match(
-            new_ref, s, tolerance=tolerance, return_ixds=True
-        ).T
-        if len(matches) == 0:
-            return None
-        else:
-            i, j = matches
-
-        return twirl_utils._find_transform(s[j], self.ref[i]) """

--- a/prose/blocks/utils.py
+++ b/prose/blocks/utils.py
@@ -631,4 +631,3 @@ class SelectiveStack(Block):
 
     def terminate(self):
         self.stack = Image(easy_median([im.data for im in self._images]))
-        

--- a/prose/blocks/utils.py
+++ b/prose/blocks/utils.py
@@ -620,6 +620,8 @@ class SelectiveStack(Block):
 
     def run(self, image: Image):
         sigma = image.fwhm
+        self.metadata = image.metadata #### EDIT
+        self.header = image.header #### EDIT
         if len(self._images) < self.n:
             self._images.append(image)
             self._sigmas.append(sigma)
@@ -631,3 +633,29 @@ class SelectiveStack(Block):
 
     def terminate(self):
         self.stack = Image(easy_median([im.data for im in self._images]))
+        self.stack.metadata = self.metadata #### EDIT
+        self.stack.header = self.header #### EDIT
+        
+        
+    #### EDIT ####
+    
+class CleanSources(Block):
+    def __init__(self, saturation_threshold=10000, name=None):
+        """Clean sources from an image
+
+        |read| :code:`Image.sources`
+
+        |write| :code:`Image.sources`
+
+        Parameters
+        ----------
+        name : str, optional
+            name of the block, by default None
+        """
+        super().__init__(name=name)
+        self.threshold = saturation_threshold
+
+    def run(self, image: Image):
+        sources = image.sources
+        cleaned_sources = [ps for ps in sources if ps.peak <= 10000]
+        image.sources = cleaned_sources

--- a/prose/blocks/utils.py
+++ b/prose/blocks/utils.py
@@ -631,3 +631,4 @@ class SelectiveStack(Block):
 
     def terminate(self):
         self.stack = Image(easy_median([im.data for im in self._images]))
+        

--- a/prose/blocks/utils.py
+++ b/prose/blocks/utils.py
@@ -620,8 +620,6 @@ class SelectiveStack(Block):
 
     def run(self, image: Image):
         sigma = image.fwhm
-        self.metadata = image.metadata #### EDIT
-        self.header = image.header #### EDIT
         if len(self._images) < self.n:
             self._images.append(image)
             self._sigmas.append(sigma)
@@ -633,29 +631,3 @@ class SelectiveStack(Block):
 
     def terminate(self):
         self.stack = Image(easy_median([im.data for im in self._images]))
-        self.stack.metadata = self.metadata #### EDIT
-        self.stack.header = self.header #### EDIT
-        
-        
-    #### EDIT ####
-    
-class CleanSources(Block):
-    def __init__(self, saturation_threshold=10000, name=None):
-        """Clean sources from an image
-
-        |read| :code:`Image.sources`
-
-        |write| :code:`Image.sources`
-
-        Parameters
-        ----------
-        name : str, optional
-            name of the block, by default None
-        """
-        super().__init__(name=name)
-        self.threshold = saturation_threshold
-
-    def run(self, image: Image):
-        sources = image.sources
-        cleaned_sources = [ps for ps in sources if ps.peak <= 10000]
-        image.sources = cleaned_sources

--- a/prose/core/image.py
+++ b/prose/core/image.py
@@ -57,8 +57,6 @@ class Image:
 
     header: Optional[Header] = None
     """FITS header associated with the image (optional)"""
-    
-    mask: np.ndarray = None ####EDIT
 
     _wcs = None
 

--- a/prose/core/image.py
+++ b/prose/core/image.py
@@ -58,6 +58,8 @@ class Image:
 
     header: Header = None
     """FITS header associated with the image (optional)"""
+    
+    mask: np.ndarray = None ####EDIT
 
     _wcs = None
 
@@ -648,6 +650,7 @@ def FITSImage(
     if image.metadata["jd"] is None:
         image.metadata["jd"] = Time(image.date).jd
     image.fits_header = header
+    image.header = header ### EDIT
     image.wcs = WCS(header)
     image.telescope = telescope
 


### PR DESCRIPTION
## Description

Re-integration of the XYShift alignment method.

## Related Issue

In the new version, the default alignment was done by 'AlignReferenceSources()', which used twirl. After discussion, Lionel suggested to reintegrate the simple XYShift algorithm as most tracking issues are translational.

## Type of Change

I integrated a boolean parameter 'XYShift' in the 'AlignReferenceSources()' block. Furthermore, I expanded the 'ComputeTransform' block into two new blocks: first I duplicated the block and called it 'ComputeTransformTwirl' and then I reimplemented the XYShift block from an earlier version as the 'ComputeTransformXYShift' block. By default the parameter 'XYShift' is set to False, and so by default twirl is used for alignment, as is done in ver 3.0.0.
I have tested the algorithm on a few example dates, by visually checking the resulting stack and it shows no streaks and other features indicating that alignment would have failed. However, proper testing has **not** been done yet.



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/lgrcia/prose/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/lgrcia/prose/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using [black](https://black.readthedocs.io/en/stable/).
- [ ] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in [numpy style](https://numpydoc.readthedocs.io/en/latest/format.html#documenting-classes) for all the methods and classes that I used.
