### PR TITLE
fix: deBroeg std issue

### DIFF
--- a/prose/fluxes.py
+++ b/prose/fluxes.py
@@ -64,6 +64,7 @@ def weights(
     while evolution > tolerance and i < max_iteration:
         if i == 0:
             weights = 1 / binned_white(dfluxes)
+            mask = np.where(~np.isfinite(weights))
         else:
             # This metric is preferred from std to optimize over white noise and not red noise
             std = binned_white(lcs)
@@ -71,16 +72,16 @@ def weights(
 
         weights[~np.isfinite(weights)] = 0
 
-        # Keep track of weights
-        evolution = np.nanstd(
-            np.abs(np.nanmean(weights, axis=-1) - np.nanmean(last_weights, axis=-1))
-        )
+        evolution = np.abs(np.nanmean(weights, axis=-1) - np.nanmean(last_weights, axis=-1))
 
         last_weights = weights
         lcs = diff(dfluxes, weights=weights)
+
         i += 1
 
-    return weights
+    weights[0,mask] = 0
+
+    return weights[0]
 
 
 def diff(fluxes: np.ndarray, weights: np.ndarray = None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prose"
-version = "3.2.1"
+version = "3.2.2"
 description = "Modular image processing pipelines for Astronomy"
 authors = ["Lionel Garcia"]
 license = "MIT"


### PR DESCRIPTION
Before, the standard deviation was applied on the mean difference between current and last weights (scalar), which resulted in the evolution parameter being zero already in the first iteration. Hence, the deBroeg algorithm only runs once when using .autodiff(). Removing the standard deviation fixes the issue.

I also tested between using the maximum difference and the mean difference of current and last weight for a few example dates. In the dates I've tested,  the results are identical, but the mean difference method uses less iterations. This is why I have settled for the mean difference approach for now.

Furthermore, I've implemented two additional lines related to any mask that is applied to a 'Fluxes' instance by using the 'mask_stars' function. Specifically, i identify stars with a std of zero in the first iteration (as 'mask_stars' sets masked stars to be -1 for all times) and then apply the mask after all iterations to the resulting weights. I did this, as before it would only set the weights to zero for these masked stars in the first iteration, but as soon as the weights are defined by the binned white noise of the lightcurve (from the second iteration onwards), the masked stars get non-zero values, which defies the purpose of masking.
