### PR TITLE
fix(#138): sequence warning before terminate + getfluxes exception fo…

### DIFF
--- a/prose/blocks/utils.py
+++ b/prose/blocks/utils.py
@@ -542,6 +542,10 @@ class GetFluxes(Get):
     def terminate(self):
         super().terminate()
         area = np.pi * (self._apertures**2)
+        if len(self._fluxes) == 0:
+            raise ValueError(
+                "block has empty fluxes (check if stars are present in image or if image has been discarded)"
+            )
         raw_fluxes = (self._fluxes - self._bkg[:, :, None] * area[:, None, :]).T
         time = self._time
         data = {"bkg": np.mean(self._bkg, -1)}

--- a/prose/core/block.py
+++ b/prose/core/block.py
@@ -106,6 +106,10 @@ class Block(object):
         """Method called after block's :py:class:`~prose.Sequence` is finished (if any)"""
         pass
 
+    def _terminate(self):
+        with _exception_context(self.__class__.__name__):
+            self.terminate()
+
     @property
     def citations(self) -> list:
         """

--- a/prose/core/sequence.py
+++ b/prose/core/sequence.py
@@ -110,13 +110,13 @@ class Sequence:
         self.discards = {}
         self._run(loader=loader)
 
-        if terminate:
-            self.terminate()
-
         for block_name, discarded in self.discards.items():
             warning(
                 f"{block_name} discarded image{'s' if len(discarded)>1 else ''} {', '.join(discarded)}"
             )
+
+        if terminate:
+            self.terminate()
 
     def _load(self, image, loader=FITSImage):
         _image = loader(image) if isinstance(image, (str, Path)) else image
@@ -143,7 +143,7 @@ class Sequence:
     def terminate(self):
         """Run the :py:class:`Block.terminate` method of all blocks"""
         for block in self.blocks:
-            block.terminate()
+            block._terminate()
         self._set_blocks_in_sequence(False)
 
     def __str__(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prose"
-version = "3.2.7"
+version = "3.2.8"
 description = "Modular image processing pipelines for Astronomy"
 authors = ["Lionel Garcia"]
 license = "MIT"


### PR DESCRIPTION
- `Sequence` warning before `terminate`
- raise exception on empty fluxes in `GetFluxes`
- `terminate` exception context to display name of block

Fixing #138 